### PR TITLE
switch to using a superclass instead of decorator

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,12 +45,11 @@ in an intuitive, user-friendly manner. Additionally, like PyTorch modules, datat
 
 ## Datablocks
 
-This module defines the `datablock` decorator, which can turn any frozen dataclass into a composable, torch-friendly datastructure. Example:
+This module defines the `Datablock` class, which can turn any frozen dataclass into a composable, torch-friendly datastructure. Example:
 
 ```python
-@datablock
-@dataclass(frozen=True)
-class ProteinSequence:
+@dataclass(frozen=True, repr=False)
+class ProteinSequence(Datablock):
     id: str
     sequence: str = field(metadata={"dim": -1})  # indicate the dimension along which slicing should occur
     tensor: torch.Tensor = field(metadata={"pad": 1, "dim": -1})  # indicate the dimension for slicing and the pad value for collating
@@ -81,6 +80,7 @@ ProteinSequence(
 ```
 
 #### Slicing
+
 ```python
 >>> sequence[:2]
 ProteinSequence(
@@ -103,7 +103,9 @@ ProteinSequence(
     device=cpu,
 )
 ```
+
 #### Shift to cuda
+
 ```python
 >>> sequence.cuda()
 ProteinSequence(
@@ -115,9 +117,11 @@ ProteinSequence(
     device=cuda,
 )
 ```
+
 #### Collate
+
 ```python
-# Moving to/from cuda will still work after collating. Slicing is not fully implemented yet.
+# Moving to/from cuda and slicing will still work after collating
 >>> ProteinSequence.collate([sequence[:2], sequence[2:]])
 ProteinSequence(
     id=["test", "test"],
@@ -133,12 +137,12 @@ ProteinSequence(
 ```
 
 #### Composability
+
 It's also possible to compose objects in a straightforward manner
 
 ```python
-@datablock
-@dataclass(frozen=True)
-class ProteinStructure:
+@dataclass(frozen=True, repr=False)
+class ProteinStructure(Datablock):
     sequence: ProteinSequence
     coords: torch.Tensor = field(metadata={"dim": -3})
 

--- a/datablocks/__init__.py
+++ b/datablocks/__init__.py
@@ -1,1 +1,1 @@
-from .datablock import datablock
+from .datablock import Datablock

--- a/datablocks/collate.py
+++ b/datablocks/collate.py
@@ -24,7 +24,7 @@ def collate_dense_tensors(
     return array
 
 
-@dataclasses.dataclass(frozen=True)
+@dataclasses.dataclass(frozen=True, kw_only=True)
 class CollateDatablockMixin:
     batch_size: int = 0
 

--- a/datablocks/datablock.py
+++ b/datablocks/datablock.py
@@ -1,47 +1,18 @@
-import dataclasses
-
 from .collate import CollateDatablockMixin
 from .sequential import SequentialDatablockMixin
 from .tensorlike import TensorlikeDatablockMixin
 
 
-def datablock(cls):
-    if not dataclasses.is_dataclass(cls):
-        raise TypeError(
-            "Trying to wrap a non-dataclass as a datablock, this is very likely to go wrong"
+class Datablock(
+    TensorlikeDatablockMixin, SequentialDatablockMixin, CollateDatablockMixin
+):
+    def __repr__(self):
+        info = ", ".join(
+            f"{key}={value}"
+            for key, value in vars(self).items()
+            if key not in ("_device", "_dtype", "batch_size")
         )
-
-    try:
-
-        @dataclasses.dataclass(frozen=True)
-        class _Datablock(
-            TensorlikeDatablockMixin,
-            SequentialDatablockMixin,
-            CollateDatablockMixin,
-            cls,
-        ):
-            def __repr__(self):
-                info = ",".join(
-                    f"{key}={value}"
-                    for key, value in vars(self).items()
-                    if key not in ("_device", "_dtype")
-                )
-                return f"{self.__class__.__name__}({info}, dtype={self.dtype}, device={self.device})"
-
-        _Datablock.__module__ = cls.__module__
-        _Datablock.__name__ = cls.__name__
-        for method in _Datablock.__dict__.values():
-            if callable(method):
-                method.__qualname__ = method.__qualname__.replace(
-                    _Datablock.__qualname__, cls.__qualname__
-                )
-        _Datablock.__qualname__ = cls.__qualname__
-        _Datablock.__annotations__ = cls.__annotations__
-        _Datablock.__doc__ = cls.__doc__
-
-    except TypeError as e:
-        if e.args[0] == "cannot inherit frozen dataclass from a non-frozen one":
-            raise TypeError("Cannot wrap a non-frozen dataclass as a datablock")
-        raise e
-
-    return _Datablock
+        if self.batch_size == 0:
+            return f"{self.__class__.__name__}({info}, dtype={self.dtype}, device={self.device})"
+        else:
+            return f"{self.__class__.__name__}({info}, batch_size={self.batch_size}, dtype={self.dtype}, device={self.device})"

--- a/datablocks/tensorlike.py
+++ b/datablocks/tensorlike.py
@@ -12,7 +12,7 @@ FLOAT_DTYPES: T.Set[torch.dtype] = {
 V = T.TypeVar("V")
 
 
-@dataclasses.dataclass(frozen=True)
+@dataclasses.dataclass(frozen=True, kw_only=True)
 class TensorlikeDatablockMixin:
     _device: T.Optional[torch.device] = None
     _dtype: T.Optional[torch.dtype] = None

--- a/poetry.lock
+++ b/poetry.lock
@@ -418,6 +418,65 @@ gmpy = ["gmpy2 (>=2.1.0a4)"]
 tests = ["pytest (>=4.6)"]
 
 [[package]]
+name = "mypy"
+version = "1.3.0"
+description = "Optional static typing for Python"
+category = "main"
+optional = false
+python-versions = ">=3.7"
+files = [
+    {file = "mypy-1.3.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:c1eb485cea53f4f5284e5baf92902cd0088b24984f4209e25981cc359d64448d"},
+    {file = "mypy-1.3.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:4c99c3ecf223cf2952638da9cd82793d8f3c0c5fa8b6ae2b2d9ed1e1ff51ba85"},
+    {file = "mypy-1.3.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:550a8b3a19bb6589679a7c3c31f64312e7ff482a816c96e0cecec9ad3a7564dd"},
+    {file = "mypy-1.3.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:cbc07246253b9e3d7d74c9ff948cd0fd7a71afcc2b77c7f0a59c26e9395cb152"},
+    {file = "mypy-1.3.0-cp310-cp310-win_amd64.whl", hash = "sha256:a22435632710a4fcf8acf86cbd0d69f68ac389a3892cb23fbad176d1cddaf228"},
+    {file = "mypy-1.3.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:6e33bb8b2613614a33dff70565f4c803f889ebd2f859466e42b46e1df76018dd"},
+    {file = "mypy-1.3.0-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:7d23370d2a6b7a71dc65d1266f9a34e4cde9e8e21511322415db4b26f46f6b8c"},
+    {file = "mypy-1.3.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:658fe7b674769a0770d4b26cb4d6f005e88a442fe82446f020be8e5f5efb2fae"},
+    {file = "mypy-1.3.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:6e42d29e324cdda61daaec2336c42512e59c7c375340bd202efa1fe0f7b8f8ca"},
+    {file = "mypy-1.3.0-cp311-cp311-win_amd64.whl", hash = "sha256:d0b6c62206e04061e27009481cb0ec966f7d6172b5b936f3ead3d74f29fe3dcf"},
+    {file = "mypy-1.3.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:76ec771e2342f1b558c36d49900dfe81d140361dd0d2df6cd71b3db1be155409"},
+    {file = "mypy-1.3.0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ebc95f8386314272bbc817026f8ce8f4f0d2ef7ae44f947c4664efac9adec929"},
+    {file = "mypy-1.3.0-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:faff86aa10c1aa4a10e1a301de160f3d8fc8703b88c7e98de46b531ff1276a9a"},
+    {file = "mypy-1.3.0-cp37-cp37m-win_amd64.whl", hash = "sha256:8c5979d0deb27e0f4479bee18ea0f83732a893e81b78e62e2dda3e7e518c92ee"},
+    {file = "mypy-1.3.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:c5d2cc54175bab47011b09688b418db71403aefad07cbcd62d44010543fc143f"},
+    {file = "mypy-1.3.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:87df44954c31d86df96c8bd6e80dfcd773473e877ac6176a8e29898bfb3501cb"},
+    {file = "mypy-1.3.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:473117e310febe632ddf10e745a355714e771ffe534f06db40702775056614c4"},
+    {file = "mypy-1.3.0-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:74bc9b6e0e79808bf8678d7678b2ae3736ea72d56eede3820bd3849823e7f305"},
+    {file = "mypy-1.3.0-cp38-cp38-win_amd64.whl", hash = "sha256:44797d031a41516fcf5cbfa652265bb994e53e51994c1bd649ffcd0c3a7eccbf"},
+    {file = "mypy-1.3.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:ddae0f39ca146972ff6bb4399f3b2943884a774b8771ea0a8f50e971f5ea5ba8"},
+    {file = "mypy-1.3.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:1c4c42c60a8103ead4c1c060ac3cdd3ff01e18fddce6f1016e08939647a0e703"},
+    {file = "mypy-1.3.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e86c2c6852f62f8f2b24cb7a613ebe8e0c7dc1402c61d36a609174f63e0ff017"},
+    {file = "mypy-1.3.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:f9dca1e257d4cc129517779226753dbefb4f2266c4eaad610fc15c6a7e14283e"},
+    {file = "mypy-1.3.0-cp39-cp39-win_amd64.whl", hash = "sha256:95d8d31a7713510685b05fbb18d6ac287a56c8f6554d88c19e73f724a445448a"},
+    {file = "mypy-1.3.0-py3-none-any.whl", hash = "sha256:a8763e72d5d9574d45ce5881962bc8e9046bf7b375b0abf031f3e6811732a897"},
+    {file = "mypy-1.3.0.tar.gz", hash = "sha256:e1f4d16e296f5135624b34e8fb741eb0eadedca90862405b1f1fde2040b9bd11"},
+]
+
+[package.dependencies]
+mypy-extensions = ">=1.0.0"
+tomli = {version = ">=1.1.0", markers = "python_version < \"3.11\""}
+typing-extensions = ">=3.10"
+
+[package.extras]
+dmypy = ["psutil (>=4.0)"]
+install-types = ["pip"]
+python2 = ["typed-ast (>=1.4.0,<2)"]
+reports = ["lxml"]
+
+[[package]]
+name = "mypy-extensions"
+version = "1.0.0"
+description = "Type system extensions for programs checked with the mypy type checker."
+category = "main"
+optional = false
+python-versions = ">=3.5"
+files = [
+    {file = "mypy_extensions-1.0.0-py3-none-any.whl", hash = "sha256:4392f6c0eb8a5668a69e23d168ffa70f0be9ccfd32b5cc2d26a34ae5b844552d"},
+    {file = "mypy_extensions-1.0.0.tar.gz", hash = "sha256:75dbf8955dc00442a438fc4d0666508a9a97b6bd41aa2f0ffe9d2f2725af0782"},
+]
+
+[[package]]
 name = "networkx"
 version = "3.1"
 description = "Python package for creating and manipulating graphs and networks"
@@ -902,7 +961,7 @@ mpmath = ">=0.19"
 name = "tomli"
 version = "2.0.1"
 description = "A lil' TOML parser"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.7"
 files = [
@@ -1062,4 +1121,4 @@ test = ["pytest (>=6.0.0)"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "9b98e4d24b17ad25b5c602022b9c00c141a9f93ec795c8687f60624f807a240f"
+content-hash = "c168de3dc69dcf72b089842518183cc1d03fca2dd0e6b0c6ff1fd9612aae1099"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ readme = "README.md"
 python = "^3.10"
 torch = "2.0.0"
 numpy = "^1.24.3"
+mypy = "^1.3.0"
 [tool.poetry.group.dev.dependencies]
 pytest = "^7.3.1"
 pytest-xdist = "^3.2.1"

--- a/tests/test_datablock.py
+++ b/tests/test_datablock.py
@@ -4,7 +4,7 @@ from dataclasses import dataclass, field
 import pytest
 import torch
 
-from datablocks import datablock
+from datablocks import Datablock
 
 """
 TODO:
@@ -20,16 +20,14 @@ TODO:
 """
 
 
-@datablock
-@dataclass(frozen=True)
-class _StringTensor:
+@dataclass(frozen=True, repr=False)
+class _StringTensor(Datablock):
     string_item: str = "test"
     tensor_item: torch.Tensor = torch.zeros([3])
 
 
-@datablock
-@dataclass(frozen=True)
-class _StringTensorPad1:
+@dataclass(frozen=True, repr=False)
+class _StringTensorPad1(Datablock):
     string_item: str = "test"
     tensor_item: torch.Tensor = field(default=torch.zeros([3]), metadata={"pad": 1})
 
@@ -111,6 +109,22 @@ def test_shift_device(data):
     assert cpu.tensor_item.device.type == "cpu"
     assert cuda.tensor_item.device.type == "cuda"
     assert torch.all(cpu.tensor_item == cuda.tensor_item.cpu())
+
+
+def test_repr_unbatched():
+    data = DATA
+    assert (
+        repr(data)
+        == "_StringTensor(string_item=test, tensor_item=tensor([0., 0., 0.]), dtype=torch.float32, device=cpu)"
+    )
+
+
+def test_repr_batched():
+    data = BATCH
+    assert repr(data) == (
+        "_StringTensor(string_item=['test', 'test'], tensor_item=tensor([[0., 0., 0.],\n        [0., 0., 0.]]), "
+        "batch_size=2, dtype=torch.float32, device=cpu)"
+    )
 
 
 def test_collate():

--- a/tests/test_hierarchical.py
+++ b/tests/test_hierarchical.py
@@ -5,21 +5,19 @@ from functools import partial
 import pytest
 import torch
 
-from datablocks import datablock
+from datablocks import Datablock
 
 
-@datablock
-@dataclass(frozen=True)
-class _StringTensorDimNeg1:
+@dataclass(frozen=True, repr=False)
+class _StringTensorDimNeg1(Datablock):
     string_item: str = field(default="abcde", metadata={"dim": -1})
     tensor_item: torch.Tensor = field(
         default=torch.arange(10).view(2, 5), metadata={"dim": -1}
     )
 
 
-@datablock
-@dataclass(frozen=True)
-class _HierarchicalStringTensor:
+@dataclass(frozen=True, repr=False)
+class _HierarchicalStringTensor(Datablock):
     block: _StringTensorDimNeg1 = field(default_factory=_StringTensorDimNeg1)
     string_item: str = field(default="abcde", metadata={"dim": -1})
     tensor_item: torch.Tensor = field(

--- a/tests/test_slicing.py
+++ b/tests/test_slicing.py
@@ -5,42 +5,37 @@ from functools import partial
 import pytest
 import torch
 
-from datablocks import datablock
+from datablocks import Datablock
 
 
-@datablock
-@dataclass(frozen=True)
-class _StringTensor:
+@dataclass(frozen=True, repr=False)
+class _StringTensor(Datablock):
     string_item: str = "test"
     tensor_item: torch.Tensor = torch.zeros([3])
 
 
-@datablock
-@dataclass(frozen=True)
-class _StringTensorPad1:
+@dataclass(frozen=True, repr=False)
+class _StringTensorPad1(Datablock):
     string_item: str = "test"
     tensor_item: torch.Tensor = field(default=torch.zeros([3]), metadata={"pad": 1})
 
 
-@datablock
-@dataclass(frozen=True)
-class _StringTensorDim0:
+@dataclass(frozen=True, repr=False)
+class _StringTensorDim0(Datablock):
     string_item: str = field(default="abcde", metadata={"dim": 0})
     tensor_item: torch.Tensor = field(default=torch.arange(5), metadata={"dim": 0})
 
 
-@datablock
-@dataclass(frozen=True)
-class _StringTensorDimNeg1:
+@dataclass(frozen=True, repr=False)
+class _StringTensorDimNeg1(Datablock):
     string_item: str = field(default="abcde", metadata={"dim": -1})
     tensor_item: torch.Tensor = field(
         default=torch.arange(10).view(2, 5), metadata={"dim": -1}
     )
 
 
-@datablock
-@dataclass(frozen=True)
-class _StringTensorMultidim:
+@dataclass(frozen=True, repr=False)
+class _StringTensorMultidim(Datablock):
     string_item: str = field(default="abcde", metadata={"dim": -1})
     tensor_item: torch.Tensor = field(
         default=torch.arange(50).view(2, 5, 5), metadata={"dim": (-1, -2)}


### PR DESCRIPTION
The decorator is nice and works at runtime, but linters (mypy + pyright) complain and IDEs have trouble following definitions to go to the right method. E.g.

```python
@datablock
@dataclass(frozen=True)
class Foo:
    baz: torch.Tensor
    
    def bar(self):
        print(self.batch_size)   # causes linting error, batch_size not part of class
        
foo = Foo()  # hover declaration shows (*args, **kwargs) as signature
```

New signature fixes these issues. Note: Must use `@dataclass(frozen=True, repr=False)` decorator to get full functionality. Looking for a way to check for this decorator in the future.